### PR TITLE
[Extension] Button now tells time to next press on early press

### DIFF
--- a/src/components/the-button.ts
+++ b/src/components/the-button.ts
@@ -226,8 +226,12 @@ export class TheButton extends BotComponent {
             }
             // check to see if the user has pressed it within the last 24 hours
             if(Date.now() - scoreboard[interaction.user.id].last_press <= PRESS_TIMEOUT) {
+                // ~~x converts the float x to an integer
+                // next_possible is the unix-time for the next possible button press
+                const next_possible = ~~((scoreboard[interaction.user.id].last_press + DAY) / 1000)
                 await interaction.reply({
-                    content: "Your may only press the button once per 24 hours",
+                    // string highlighting is screwed, because of the '<' and '>' characters
+                    content: `You can press the button again <t:${next_possible}:R>`,
                     ephemeral: true
                 });
                 return;

--- a/src/components/the-button.ts
+++ b/src/components/the-button.ts
@@ -228,7 +228,7 @@ export class TheButton extends BotComponent {
             if(Date.now() - scoreboard[interaction.user.id].last_press <= PRESS_TIMEOUT) {
                 // ~~x converts the float x to an integer
                 // next_possible is the unix-time for the next possible button press
-                const next_possible = ~~((scoreboard[interaction.user.id].last_press + DAY) / 1000)
+                const next_possible = ~~((scoreboard[interaction.user.id].last_press + PRESS_TIMEOUT) / 1000)
                 await interaction.reply({
                     // string highlighting is screwed, because of the '<' and '>' characters
                     content: `You can press the button again <t:${next_possible}:R>`,

--- a/src/components/the-button.ts
+++ b/src/components/the-button.ts
@@ -228,7 +228,7 @@ export class TheButton extends BotComponent {
             if(Date.now() - scoreboard[interaction.user.id].last_press <= PRESS_TIMEOUT) {
                 // ~~x converts the float x to an integer
                 // next_possible is the unix-time for the next possible button press
-                const next_possible = ~~((scoreboard[interaction.user.id].last_press + PRESS_TIMEOUT) / 1000)
+                const next_possible = ~~((scoreboard[interaction.user.id].last_press + PRESS_TIMEOUT) / 1000);
                 await interaction.reply({
                     // string highlighting is screwed, because of the '<' and '>' characters
                     content: `You can press the button again <t:${next_possible}:R>`,


### PR DESCRIPTION
When The Button is pressed instead of telling the user he has to wait 24 hours, it prints a timestamp for when they can press it again.