### PR TITLE
Fix CRLF line splitting

### DIFF
--- a/src/components/wiki.ts
+++ b/src/components/wiki.ts
@@ -36,7 +36,7 @@ export function parse_article(name: string | null, content: string): [WikiArticl
     const data: Partial<WikiArticle> = {};
     data.body = "";
     data.fields = [];
-    const lines = content.split("\n");
+    const lines = content.split(/\r?\n/);
     enum state { body, field, footer }
     let code = false;
     let current_state = state.body;


### PR DESCRIPTION
When the repo is pulled onto a Windows machine, the line line endings are automatically converted to CRLF. This breaks the line in question, because a trailing `\r` is left in the string.

The regex patterns used for parsing don't account for this, and fail to match.