### PR TITLE
Fix title case in articles

### DIFF
--- a/wiki_articles/c_vs_cpp.md
+++ b/wiki_articles/c_vs_cpp.md
@@ -4,13 +4,13 @@ Neither language is better, neither language is faster.
 There are good reasons for using both languages:
 
 <!-- inline -->
-## Reasons To Use C
+## Reasons to Use C
 :white_check_mark: relatively low-level language<br>
 :white_check_mark: much simpler language (no classes, templates, ...)<br>
 :white_check_mark: portable to a wide variety of systems
 
 <!-- inline -->
-## Reasons To Use C++
+## Reasons to Use C++
 :white_check_mark: lots of helpful abstractions (classes, templates, ...)<br>
 :white_check_mark: feature-rich language (function overloads, `constexpr`, ...)<br>
 :white_check_mark: extensive standard library

--- a/wiki_articles/casts.md
+++ b/wiki_articles/casts.md
@@ -1,4 +1,4 @@
-# What are the different casts in C++
+# What Are the different casts in C++
 
 **[static_cast](https://en.cppreference.com/w/cpp/language/static_cast)**<br>
 Converts using implicit and user-defined conversions.

--- a/wiki_articles/cdecl.md
+++ b/wiki_articles/cdecl.md
@@ -7,7 +7,7 @@ Append whatever is left in the end.
 - `*` means *pointer to*; `* const` means *const pointer to*
 - parentheses can be used to apply `*` before `()` or `[]`
 
-## Example 1 - Array of Pointers, Or Pointer to Array?
+## Example 1 - Array of Pointers, or Pointer to Array?
 ```cpp
 int (*ptr)[10]; // declare
       ptr       // ptr as
@@ -17,7 +17,7 @@ int __________  // int
 // note: int *arr[10] would be an array of pointers
 ```
 
-## Example 2 - Nested Pointers With `const`
+## Example 2 - Nested Pointers with `const`
 ```cpp
 int const * const * p; // declare
                     p  // p as

--- a/wiki_articles/channel.md
+++ b/wiki_articles/channel.md
@@ -1,4 +1,4 @@
-# Asking Your Question In the Right Channel
+# Asking Your Question in the Right Channel
 
 Welcome to Together C & C++.
 We have many channels on various topics, and encourage you to explore the channel list.

--- a/wiki_articles/cheats.md
+++ b/wiki_articles/cheats.md
@@ -1,9 +1,9 @@
 <!-- user author -->
 <!-- alias cheats -->
 
-# We do not help with anything pertaining to cheating/hacking/malware.
+# We Do Not Help with Anything Pertaining to Cheating/Hacking/Malware
 Aside from ethics and simply not caring for helping script kiddies,
-this content violates Discord's terms of service and we do not tolerate it.
+this content violates Discord's terms of service, and we do not tolerate it.
 
 ## See Also
 - Our <#659868782877212723>, 6.

--- a/wiki_articles/class_struct.md
+++ b/wiki_articles/class_struct.md
@@ -1,4 +1,4 @@
-# What is the Difference Between class and struct?
+# What Is the Difference Between class and struct?
 
 The keywords
 **[class](https://en.cppreference.com/w/cpp/keyword/class)** and

--- a/wiki_articles/conditional.md
+++ b/wiki_articles/conditional.md
@@ -18,7 +18,7 @@ int min(int a, int b) {
 This function chooses `a` if `a` is lower than `b`, or `b` otherwise.
 
 <!-- inline -->
-## Benefits Over If-Statements
+## Benefits over If-Statements
 - more concise code
 - makes it easier to be `const`-correct
 

--- a/wiki_articles/endl.md
+++ b/wiki_articles/endl.md
@@ -1,4 +1,4 @@
-# About `std::endl`, Buffers, And Flushing
+# About `std::endl`, Buffers, and Flushing
 
 I/O in C++ (`std::cout`, i.e.`std::ostream`) is *buffered*,
 which means that not every byte you write to the stream is instantly written through to the terminal/disk.
@@ -9,7 +9,7 @@ all data is written through to the OS (flushed) in one syscall.
 This is much more efficient.
 
 <!-- inline -->
-## What is *flushing*?
+## What Is *flushing*?
 *Flushing* means that all bytes currently in the buffer are written through, and the buffer is cleared.
 
 Use `<< std::flush` to flush, or use `std::cerr`, which is unbuffered.

--- a/wiki_articles/formatting.md
+++ b/wiki_articles/formatting.md
@@ -1,4 +1,4 @@
-# Why Should I Format My Code, And How Do I Do It?
+# Why Should I Format My Code, and How Do I Do It?
 
 Well-formatted code is much easier to read, especially for people who haven't
 written it themselves.
@@ -11,13 +11,13 @@ while (is_waiting) { } // good, empty statement
 std::cout << "hi\n";   // is clearly visible
 ```
 
-## Rules For Code Formatting
+## Rules for Code Formatting
 1. Stay consistent! (much easier when using auto-formatters)
 2. Don't use exotic styles that surprise readers.
 3. The rest is up to personal preference.
 
 <!-- inline -->
-## Auto-Formatting With clang-format
+## Auto-Formatting with clang-format
 For C/C++, you can use
 **[clang-format](https://clang.llvm.org/docs/ClangFormat.html)**
 to decide on a style, and apply it automatically to your files.

--- a/wiki_articles/iterators.md
+++ b/wiki_articles/iterators.md
@@ -1,4 +1,4 @@
-# Iterators And Pointers
+# Iterators and Pointers
 
 Iterators in C++ are lightweight, non-owning types which provide a view into a range of elements.
 They must satisfy [named requirements](https://en.cppreference.com/w/cpp/named_req), or

--- a/wiki_articles/naming.md
+++ b/wiki_articles/naming.md
@@ -1,4 +1,4 @@
-# How To Name Your Variables
+# How to Name Your Variables
 
 - names should be short, but descriptive
 - avoid single-character names like `a`

--- a/wiki_articles/safety.md
+++ b/wiki_articles/safety.md
@@ -1,4 +1,4 @@
-# How To Write Safer C/C++ Code
+# How to Write Safer C/C++ Code
 
 C and C++ are very powerful languages, but you need to be careful when using them.
 Here are some crucial practices:

--- a/wiki_articles/sequencing.md
+++ b/wiki_articles/sequencing.md
@@ -1,4 +1,4 @@
-# What Is Sequencing, And What Are Sequence Points?
+# What Is Sequencing, and What Are Sequence Points?
 
 Some operations in C++ are *sequenced* before others, meaning that they happen
 first.

--- a/wiki_articles/virtual_dtor.md
+++ b/wiki_articles/virtual_dtor.md
@@ -1,4 +1,4 @@
-# Why do we need a virtual destructor?
+# When Do We Need a Virtual Destructor?
 
 [As stated by the C++ standard](https://timsong-cpp.github.io/cppwp/n4868/expr.delete#3),
 when we `delete` a `base*` which is actually pointing to a `derived` which inherits from `base`,

--- a/wiki_articles/vla.md
+++ b/wiki_articles/vla.md
@@ -1,6 +1,6 @@
 <!-- alias vla -->
 
-# What Is a VLA And Why Is It "Bad"?
+# What Is a VLA, and Why Is It "Bad"?
 
 A [Variable Length Array (VLA)](https://en.cppreference.com/w/c/language/array#Variable-length_arrays)
 is an array where the size is not constant and depends on a variable.
@@ -14,7 +14,7 @@ constexpr int size = 10;
 int arr[size]; // also not a VLA, of type int[10]
 ```
 
-## Why are VLAs "Bad"?
+## Why Are VLAs "Bad"?
 VLAs have poor compiler support and can lead to unsafe code.
 The core issue with VLAs is that the compiler doesn't know the size of the stack frame.
 Without warning flags like `-Wvla`, it can be easy to create a VLA by accident, even in C++ with some compilers.


### PR DESCRIPTION
Some articles have title case which is inconsistent with the style established in #24.

Note that most titles have already been following this guide before, just not consistently because I didn't know well enough how to use Wikipedia title case when writing them, and I didn't double check.