### PR TITLE
Wiki placeholders

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -53,7 +53,7 @@ export const the_button_channel_id = "1069678919667687455";
 export const skill_role_suggestion_log_id = "1099193160858599484";
 export const starboard_channel_id = "800509841424252968";
 export const announcements_channel_id = "331881381477089282";
-export const resources_channel_id = "574580408407293954";
+export const resources_channel_id = "1124619767542718524";
 export const staff_action_log_channel_id = "845290775692443699";
 
 // Thread-based help channels

--- a/src/common.ts
+++ b/src/common.ts
@@ -7,6 +7,7 @@ import { is_string, M } from "./utils.js";
 export const MINUTE = 1000 * 60;
 
 export const pepereally = "<:pepereally:643881257624666112>";
+export const stackoverflow_emote = "<:stackoverflow:1074747016644661258>";
 
 export const ApplicationCommandTypeUser = 2;
 export const ApplicationCommandTypeMessage = 3;

--- a/src/components/wiki.ts
+++ b/src/components/wiki.ts
@@ -5,7 +5,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 import { M } from "../utils.js";
-import { bot_spam_id, colors, rules_channel_id, stackoverflow_emote } from "../common.js";
+import { bot_spam_id, colors, resources_channel_id, rules_channel_id, stackoverflow_emote } from "../common.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
 import { TextBasedCommand, TextBasedCommandBuilder } from "../command.js";
@@ -224,6 +224,7 @@ class ArticleParser {
         return str
             .replace(/<br>\n|<br\/>\n/, "\n")
             .replaceAll(/<br>|<br\/>/g, "\n")
+            .replaceAll(/#resources(?![a-zA-Z0-9_])/g, `<#${resources_channel_id}>`)
             .replaceAll(/#rules(?![a-zA-Z0-9_])/g, `<#${rules_channel_id}>`)
             .replaceAll(/(?<!<):stackoverflow:/g, stackoverflow_emote);
     }

--- a/src/components/wiki.ts
+++ b/src/components/wiki.ts
@@ -195,14 +195,14 @@ class ArticleParser {
      */
     private substitute_placeholders(line: string): string {
         if(this.in_code) return line;
-        let result = '';
-        let piece = '';
+        let result = "";
+        let piece = "";
         let in_inline_code = false;
         for(const c of line) {
-            if (c === '`') {
+            if (c === "`") {
                 if (in_inline_code) {
                     result += piece + c;
-                    piece = '';
+                    piece = "";
                 } else  {
                     result += this.substitute_placeholders_no_code(piece);
                     piece = c;

--- a/src/components/wiki.ts
+++ b/src/components/wiki.ts
@@ -5,7 +5,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 import { M } from "../utils.js";
-import { bot_spam_id, colors } from "../common.js";
+import { bot_spam_id, colors, rules_channel_id, stackoverflow_emote } from "../common.js";
 import { BotComponent } from "../bot-component.js";
 import { Wheatley } from "../wheatley.js";
 import { TextBasedCommand, TextBasedCommandBuilder } from "../command.js";
@@ -86,7 +86,7 @@ class ArticleParser {
         this.current_state = parse_state.done;
     }
 
-    parse_line(line: string): void {
+    private parse_line(line: string): void {
         const trimmed = line.trim();
         if(trimmed.startsWith("```")) {
             this.in_code = !this.in_code;
@@ -105,7 +105,7 @@ class ArticleParser {
      * Parses one line, starting with #.
      * @param line the line
      */
-    parse_heading(line: string): void {
+    private parse_heading(line: string): void {
         const level = line.search(/[^#]/);
         assert(level >= 1, "Cannot parse heading that has no heading level");
 
@@ -129,7 +129,7 @@ class ArticleParser {
      * This function accepts the contents of such a comment, without the opening `<!--` and closing `-->`.
      * @param directive the directive to parse
      */
-    parse_directive(directive: string): void {
+    private parse_directive(directive: string): void {
         if(directive === "inline") {
             this.current_state = parse_state.before_inline_field;
         } else if(directive === "footer") {
@@ -152,16 +152,15 @@ class ArticleParser {
         }
     }
 
-    parse_regular_line(line: string): void {
+    private parse_regular_line(line: string): void {
         const requires_line_break = this.in_code ||
             line.startsWith("```") ||
             line.startsWith("#") ||
             line.trim() === "" ||
             line.trim().startsWith("- ") ||
             line.trim().match(/^\d+.*$/);
-        const terminated_line = (requires_line_break ? line + "\n" : line)
-            .replace(/<br>\n|<br\/>\n/, "\n")
-            .replaceAll(/<br>|<br\/>/g, "\n");
+        const terminator = requires_line_break ? "\n" : "";
+        const terminated_line = this.substitute_placeholders(line + terminator);
 
         const plus_line = (prefix: string) => {
             if (prefix.length !== 0) {
@@ -187,6 +186,46 @@ class ArticleParser {
         } else {
             assert(false);
         }
+    }
+
+    /**
+     * Substitutes placeholders such as <br> in the string, but only outside
+     * inline code.
+     * @param line the line, possibly containing backticks for inline code
+     */
+    private substitute_placeholders(line: string): string {
+        if(this.in_code) return line;
+        let result = '';
+        let piece = '';
+        let in_inline_code = false;
+        for(const c of line) {
+            if (c === '`') {
+                if (in_inline_code) {
+                    result += piece + c;
+                    piece = '';
+                } else  {
+                    result += this.substitute_placeholders_no_code(piece);
+                    piece = c;
+                }
+                in_inline_code = !in_inline_code;
+            } else {
+                piece += c;
+            }
+        }
+        return result + (in_inline_code ? piece : this.substitute_placeholders_no_code(piece));
+    }
+
+    /**
+     * Substitutes placeholders in a string with no backticks, i.e. no
+     * possibility of having inline code.
+     * @param str the string to substitute in
+     */
+    private substitute_placeholders_no_code(str: string): string {
+        return str
+            .replace(/<br>\n|<br\/>\n/, "\n")
+            .replaceAll(/<br>|<br\/>/g, "\n")
+            .replaceAll(/#rules(?![a-zA-Z0-9_])/g, `<#${rules_channel_id}>`)
+            .replaceAll(/(?<!<):stackoverflow:/g, stackoverflow_emote);
     }
 
     get is_done(): boolean {

--- a/src/wheatley.ts
+++ b/src/wheatley.ts
@@ -155,14 +155,18 @@ export class Wheatley extends EventEmitter {
 
     async setup(token: string) {
         this.client.on("ready", async () => {
-            await this.fetch_guild_info();
+            if (!this.freestanding) {
+                await this.fetch_guild_info();
+            }
             this.emit("wheatley_ready");
             this.ready = true;
             this.client.on("messageCreate", this.on_message.bind(this));
             this.client.on("interactionCreate", this.on_interaction.bind(this));
             this.client.on("messageDelete", this.on_message_delete.bind(this));
             this.client.on("messageUpdate", this.on_message_update.bind(this));
-            await this.populate_caches();
+            if (!this.freestanding) {
+                await this.populate_caches();
+            }
         });
 
         await this.add_component(Cppref);


### PR DESCRIPTION
Depends on #28.

This PR adds the infrastructure for various kinds of placeholders. Firstly, inline code wasn't handled correctly before, and `<br>` in inline code would produce a line break.

The goal is for us to write `#rules` and `:stackoverflow:` in the articles, and for this to turn into the correct emotes and channel mentions.